### PR TITLE
ci(perf): enable dependency caching for faster builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,15 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+      
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
       - name: Install Dependencies
         run: bun install
       - name: Run Linter
@@ -43,6 +52,15 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+      
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
       - name: Install Dependencies
         run: bun install
       - name: Run Tests
@@ -58,6 +76,15 @@ jobs:
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
+      
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
       - name: Install Dependencies
         run: bun install
       - name: Build Project


### PR DESCRIPTION
## Context
The current CI workflow installs dependencies from scratch in every job (`lint`, `test`, `build`), wasting time and bandwidth.

## Proposed Changes

### `.github/workflows/ci.yml`
Update `oven-sh/setup-bun@v2` action usage to include caching:

```yaml
      - name: Setup Bun
        uses: oven-sh/setup-bun@v2
        with:
          bun-version: latest
          # Enable caching
          cache: 'npm' # or 'bun' if available in v2, strictly 'npm' is usually fine for bun.lock
```

*Wait, `oven-sh/setup-bun` handles caching if properly configured. Let's verify documentation.*
Actually, `setup-bun` doesn't have a simple `cache: 'npm'` input like `setup-node`. It usually requires manual caching or `actions/cache`.

**Correction:**
We will use `actions/cache` to cache `~/.bun/install/cache` (Global cache) or `node_modules`.
Since Bun installs are very fast, caching the global cache is often enough.

Strategy:
1. Define a `cache-deps` composite step OR just add `actions/cache` to the workflow.
2. Cache path: `~/.bun/install/cache`.
3. Key: `${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}`.

## Verification Plan

### Automated
1. Push changes.
2. Observe CI run time.
3. Verify that the "Cache" step hits on the second run.