### PR TITLE
chore(infra): add healthchecks to docker-compose services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,11 @@ services:
     volumes:
       - ./.docker/redis/storage:/data
       - ./.docker/redis/modules:/usr/lib/redis/modules
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
   postgres:
     image: postgres:alpine
@@ -26,6 +31,11 @@ services:
     volumes:
       - ./.docker/postgres/scripts/init.sql:/docker-entrypoint-initdb.d/init.sql
       - ./.docker/postgres/storage:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DATABASE}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
   uptime:
     restart: unless-stopped


### PR DESCRIPTION
## Context
Services like PostgreSQL and Redis take time to start. Without healthchecks, dependent services (like the API) might fail to connect on startup or during CI tests that use containers.

## Proposed Changes

### `docker-compose.yml`
Add `healthcheck` blocks to:
1. **Postgres**: Use `pg_isready -U user`.
2. **Redis**: Use `redis-cli ping`.

Example config:
```yaml
    healthcheck:
      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DATABASE}"]
      interval: 5s
      timeout: 5s
      retries: 5
```

## Documentation Updates
- Update `wiki/CI-CD-Pipeline.md` to mention the caching optimization implemented in Improvement 3 (addressing user's question).

## Verification Plan
1. `docker-compose up -d`
2. `docker ps` to see (health: starting) -> (health: healthy).