### PR TITLE
docs(refactor): Ddocumentation env selector

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -3,6 +3,7 @@ name: Deploy Docs (Preview)
 on:
   push:
     branches:
+      - main
       - staging
       
   workflow_dispatch:
@@ -35,9 +36,11 @@ jobs:
         working-directory: docs
         env:
           VITE_APP_VERSION: ${{ env.VERSION }}
+          VITE_APP_ENV: ${{ github.ref_name }}
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: docs/.vitepress/dist
+          destination_dir: ${{ github.ref_name == 'staging' && 'staging' || '.' }}

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -4,10 +4,11 @@ import { vitepressMermaidPreview } from 'vitepress-mermaid-preview';
 import pkg from '../../package.json'
 
 const version = process.env.VITE_APP_VERSION || pkg.version
-
+const environment = process.env.VITE_APP_ENV || 'main'
+const isStaging = environment === 'staging'
 
 export default defineConfig({
-    base: '/TypeScript-Boilerplate/',
+    base: isStaging ? '/TypeScript-Boilerplate/staging/' : '/TypeScript-Boilerplate/',
     markdown: {
         config(md) {
             md.use(groupIconMdPlugin);
@@ -24,7 +25,6 @@ export default defineConfig({
             provider: "local"
         },
         nav: [
-            { text: `v${version}`, link: 'https://github.com/rslucena/TypeScript-Boilerplate/releases' },
             { text: "Home", link: "/" },
             { text: "Guide", link: "/guide/getting-started" },
             { text: "Reference", link: "/reference/cache-actions-reference" },

--- a/docs/.vitepress/theme/components/EnvironmentSelector.vue
+++ b/docs/.vitepress/theme/components/EnvironmentSelector.vue
@@ -1,0 +1,131 @@
+<script setup lang="ts">
+import { useData } from 'vitepress'
+import { computed } from 'vue'
+
+const { site, theme } = useData()
+
+const version = computed(() => theme.value.version || '1.0.0')
+
+const currentEnv = computed(() => {
+  return typeof window !== 'undefined' && window.location.pathname.includes('/staging/') ? 'Staging' : 'Main'
+})
+
+const switchEnv = () => {
+  if (typeof window === 'undefined') return
+  const isStaging = currentEnv.value === 'Staging'
+  const repoBase = '/TypeScript-Boilerplate/'
+  
+  if (isStaging) {
+    window.location.href = repoBase
+  } else {
+    window.location.href = `${repoBase}staging/`
+  }
+}
+
+const goToReleases = () => {
+  if (typeof window !== 'undefined') {
+    window.open('https://github.com/rslucena/TypeScript-Boilerplate/releases', '_blank')
+  }
+}
+</script>
+
+<template>
+  <div class="env-selector-wrapper">
+    <div class="version-tag" @click="goToReleases">
+      v{{ version }}
+    </div>
+    <div class="env-selector" @click="switchEnv" :title="`Switch to ${currentEnv === 'Main' ? 'Staging' : 'Main'}`">
+      <div class="env-badge" :class="currentEnv.toLowerCase()">
+        <span class="dot"></span>
+        <span class="env-text">{{ currentEnv }}</span>
+        <span class="chevron">▼</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.env-selector-wrapper {
+  display: flex;
+  align-items: center;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 8px;
+  padding: 2px;
+  margin-left: 12px;
+  height: fit-content;
+  align-self: center;
+}
+
+.version-tag {
+  font-size: 11px;
+  font-weight: 600;
+  padding: 2px 8px;
+  color: var(--vp-c-text-2);
+  cursor: pointer;
+  border-right: 1px solid var(--vp-c-divider);
+}
+
+.version-tag:hover {
+  color: var(--vp-c-brand-1);
+}
+
+.env-selector {
+  display: flex;
+  align-items: center;
+  padding: 0 4px;
+  cursor: pointer;
+  user-select: none;
+}
+
+.env-badge {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  transition: all 0.2s ease;
+}
+
+.env-badge:hover {
+  background: var(--vp-c-bg-soft);
+}
+
+.dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+}
+
+.main .dot {
+  background-color: #10b981;
+}
+
+.staging .dot {
+  background-color: #f59e0b;
+}
+
+.env-text {
+  line-height: 1;
+  color: var(--vp-c-text-1);
+}
+
+.chevron {
+  font-size: 7px;
+  opacity: 0.5;
+}
+
+.env-badge:hover .chevron {
+  opacity: 1;
+}
+
+@media (max-width: 959px) {
+  .env-selector-wrapper {
+    margin-left: 8px;
+    margin-right: 0;
+  }
+}
+</style>
+

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -7,14 +7,15 @@ import 'vitepress-mermaid-preview/dist/index.css';
 import Footer from './Footer.vue'
 import './style.css'
 
-
 import InteractiveFlow from './components/InteractiveFlow.vue'
 import DiagramBuilder from './components/DiagramBuilder.vue'
+import EnvironmentSelector from './components/EnvironmentSelector.vue'
 
 export default {
     extends: DefaultTheme,
     Layout: () => {
         return h(DefaultTheme.Layout, null, {
+            'nav-bar-content-after': () => h(EnvironmentSelector),
             'layout-bottom': () => h(Footer)
         });
     },


### PR DESCRIPTION
### Context
Currently, the documentation does not clearly distinguish between the `Main` (Production/Release) and `Staging` (Development) versions. This leads to confusion regarding which version of the code the documentation refers to.

### Proposed Changes
- **Unified Selector**: Merged the code version (`v1.0.0`) and the environment label (`MAIN`/`STAGING`) into a single cohesive UI element in the navbar.
- **Dynamic Routing**: Updated VitePress configuration to handle dynamic `base` paths based on the `VITE_APP_ENV` variable.
- **CI/CD Automation**: Modified GitHub Actions to deploy `main` branch to the root and `staging` branch to the `/staging/` subpath.
- **Positioning**: Placed the selector in the `nav-bar-content-after` slot to align with menu links.

## Implementation Details

### [Component] EnvironmentSelector.vue
- **Goal**: Provide a clickable UI to switch environments and view the current version.
- **Logic**: Detects environment via `window.location.pathname`.
- **Style**: Uses VitePress design tokens for a native look.

### [Config] .vitepress/config.ts
- **Goal**: Inject base path and environment variables.
- **Change**: `base: isStaging ? '/TypeScript-Boilerplate/staging/' : '/TypeScript-Boilerplate/'`.

### [Workflow] deploy-docs.yml
- **Goal**: Automate multi-environment deployment.
- **Change**: Added `destination_dir` logic and multi-branch triggers.

## Verification Plan
1. **Local Dev**: Run `VITE_APP_ENV=staging bun run dev` and verify base path is `/staging/`.
2. **Visual Check**: Ensure the selector is correctly placed next to the navbar menu links.
3. **Link Check**: Verify that clicking the version redirects to GitHub releases and clicking the environment badge triggers a redirect.