### PR TITLE
fix(ci): bypass environment validation for key generation script in build

### DIFF
--- a/src/commands/generate-keys.ts
+++ b/src/commands/generate-keys.ts
@@ -7,34 +7,37 @@ mkdirSync("./keys", { recursive: true });
 
 const { publicKey, privateKey } = generateRSAKeyPair();
 
-writeFileSync(`${env.APP_FOLDER_KEY}/private.pem`, privateKey);
-writeFileSync(`${env.APP_FOLDER_KEY}/public.pem`, publicKey);
+const folderKey = env.APP_FOLDER_KEY || "./keys";
+writeFileSync(`${folderKey}/private.pem`, privateKey);
+writeFileSync(`${folderKey}/public.pem`, publicKey);
 
 console.log("⏳ Generating certificate...");
 execSync(
-	`openssl req -x509 -new -nodes -key ${env.APP_FOLDER_KEY}/private.pem -sha256 -days 365 -out ${env.APP_FOLDER_KEY}/cert.pem -subj "/C=BR/ST=SP/L=SaoPaulo/O=Development/CN=localhost"`,
+	`openssl req -x509 -new -nodes -key ${folderKey}/private.pem -sha256 -days 365 -out ${folderKey}/cert.pem -subj "/C=BR/ST=SP/L=SaoPaulo/O=Development/CN=localhost"`,
 	{ stdio: "inherit" },
 );
 
 const jwk = pemToJWK(publicKey);
 const jwks = createJWKS([jwk]);
 
-writeFileSync(`${env.APP_FOLDER_KEY}/jwks.json`, JSON.stringify(jwks, null, 2));
+writeFileSync(`${folderKey}/jwks.json`, JSON.stringify(jwks, null, 2));
 
 console.log("✔ Keys geradas");
 console.log("✔ JWKS gerado");
 console.log("✔ Kid:", jwk.kid);
 
-writeFileSync(`${env.APP_FOLDER_KEY}/metadata.json`, JSON.stringify({ kid: jwk.kid }, null, 2));
+writeFileSync(`${folderKey}/metadata.json`, JSON.stringify({ kid: jwk.kid }, null, 2));
 
-const domain = `${env.PROCESS_DOMAIN}:${env.PROCESS_PORT}`;
+const processDomain = env.PROCESS_DOMAIN || "http://localhost";
+const processPort = env.PROCESS_PORT || 3000;
+const domain = `${processDomain}:${processPort}`;
 
 const openidConfiguration = {
 	issuer: domain,
 	authorization_endpoint: `${domain}/api/v1/sso/authorize`,
 	token_endpoint: `${domain}/api/v1/sso/token`,
-	userinfo_endpoint: `${env.PROCESS_DOMAIN}:${env.PROCESS_PORT}/api/v1/sso/userinfo`,
-	jwks_uri: `${env.PROCESS_DOMAIN}:${env.PROCESS_PORT}/api/v1/sso/jwks`,
+	userinfo_endpoint: `${domain}/api/v1/sso/userinfo`,
+	jwks_uri: `${domain}/api/v1/sso/jwks`,
 	scopes_supported: ["openid", "profile", "email"],
 	response_types_supported: ["code"],
 	grant_types_supported: ["authorization_code", "refresh_token"],
@@ -42,6 +45,6 @@ const openidConfiguration = {
 	id_token_signing_alg_values_supported: ["RS256"],
 };
 
-writeFileSync(`${env.APP_FOLDER_KEY}/openid-configuration.json`, JSON.stringify(openidConfiguration, null, 2));
+writeFileSync(`${folderKey}/openid-configuration.json`, JSON.stringify(openidConfiguration, null, 2));
 
 console.log("✔ Metadata gerado");

--- a/src/infrastructure/settings/environment.ts
+++ b/src/infrastructure/settings/environment.ts
@@ -36,7 +36,7 @@ const result = schema.safeParse(process.env);
 
 if (!result.success) {
 	const isTest = process.env.NODE_ENV === "test";
-	const isBuild = process.argv.some((arg) => arg.includes("exec-builder.ts"));
+	const isBuild = process.argv.some((arg) => arg.includes("exec-builder.ts") || arg.includes("generate-keys.ts"));
 
 	if (!isTest && !isBuild) {
 		const { fieldErrors } = result.error.flatten();


### PR DESCRIPTION
## Context
The CI pipeline is failing during the `bun run build` step because the `prebuild` script runs `gen:keys` (`bun src/commands/generate-keys.ts`). This script imports the `env` object from `src/infrastructure/settings/environment.ts`, which enforces strict validation of all application environment variables (like `PROCESS_DOMAIN`, `REDIS_SERVER`, `POSTGRES_SERVER`, etc.). Since the CI GitHub Actions environment does not have a fully populated `.env` file, the validation throws an `❌ Invalid environment variables` error and exits with code 1.

## Proposed Changes

We will modify the environment setting validation so that it is bypassed when running the `generate-keys.ts` script, similar to how it is currently bypassed for `exec-builder.ts` during build phases. Since the environment variables will be `undefined` when bypassed, we will also add fallback values in the `generate-keys.ts` script to ensure it can successfully generate the required PEM keys and metadata files without throwing errors.

1. **`backend/src/infrastructure/settings/environment.ts`**:
   - Update the `isBuild` check to also include `generate-keys.ts`.
   
2. **`backend/src/commands/generate-keys.ts`**:
   - Provide a fallback value for `folderKey` (e.g., `"./keys"` or a fallback to `env.APP_FOLDER_KEY`).
   - Construct the `domain` string safely using fallbacks for `env.PROCESS_DOMAIN` and `env.PROCESS_PORT`.

### Logic Diagram
```mermaid
flowchart TD
    A[CI github action] --> B[bun run build]
    B --> C[prebuild: bun run gen:keys]
    C --> D[generate-keys.ts]
    D --> E{environment.ts check}
    E -->|isBuild = true| F[Bypass validation]
    F --> G[generate-keys.ts uses fallbacks]
    G --> H[Keys generated in ./keys]
    H --> I[Build passes]
```

### Benefits
- [x] Unblocks the CI pipeline.
- [x] Improves developer experience by allowing dummy keys generation without needing a `.env` file for builds.

### Does it resolve any issues?
- Fixes backend build error in CI.

### Type of change
- [x] Bug fix

### Checklist
- [x] Modifications do not generate new error or warning logs.
- [x] Both new and old tests are passing locally.
- [x] No sensitive data (tokens, secrets, credentials) was introduced.

## Verification Plan

### Automated Tests
1. Run `mv .env .env.backup || true` to simulate the CI environment locally.
2. Run `bun run gen:keys` in the `backend/` directory. It should successfully generate the `.pem` keys in the `./keys` folder without exiting with an error.
3. Run `bun run build`. It should invoke the `prebuild` cleanly and finish the build.
4. Run `mv .env.backup .env` to restore the environment file.